### PR TITLE
First pass at implementing revised quizzes API (#8)

### DIFF
--- a/heymans/config.py
+++ b/heymans/config.py
@@ -25,6 +25,7 @@ dummy_model = bool(int(os.environ.get('HEYMANS_DUMMY_MODEL', 0)))
 min_answer_length = 2
 # The maximum duration in seconds that grading a single attempt should take
 grading_task_timeout = 60
+validation_task_timeout = 300
 
 
 # DOCUMENTS

--- a/heymans/convert.py
+++ b/heymans/convert.py
@@ -76,7 +76,7 @@ def from_markdown_exam(exam: str | Path, quiz_id: None | int = None) -> dict:
         if any(not part.startswith('-') or '\n' in part .strip()
                for part in parts[1:] if part.strip()):
             raise ValueError(
-                f'Invalid exam format: Answer key points should start with -')
+                'Invalid exam format: Answer key points should start with -')
         answer_key = [key.lstrip('-').strip() for key in parts[1:]]
 
         # Append to questions list

--- a/heymans/database/models.py
+++ b/heymans/database/models.py
@@ -64,6 +64,7 @@ class Quiz(Model):
     quiz_id = Column(Integer, primary_key=True)
     user_id = Column(Integer, ForeignKey('user.user_id'), nullable=False)
     name = Column(String, nullable=False)
+    validation = Column(Text, nullable=True)
 
     # Each Quiz has multiple Questions, so we define a one-to-many relationship
     questions = relationship('Question', back_populates='quiz')
@@ -76,6 +77,7 @@ class Question(Model):
 
     question_id = Column(Integer, primary_key=True)
     quiz_id = Column(Integer, ForeignKey('quiz.quiz_id'), nullable=False)
+    name = Column(String, nullable=True)
     text = Column(Text, nullable=False)
     answer_key = Column(Text)
 

--- a/heymans/database/operations/quizzes.py
+++ b/heymans/database/operations/quizzes.py
@@ -1,8 +1,7 @@
 import logging
 import json
 from ..models import db, NoResultFound, Quiz, Question, Attempt, User
-from ..schemas import QuizSchema, QuestionSchema, AttemptSchema
-from sqlalchemy.orm.exc import NoResultFound
+from ..schemas import QuizSchema
 
 logger = logging.getLogger('heymans')
 
@@ -27,28 +26,64 @@ def _get_quiz(quiz_id: int, user_id: int):
         raise ValueError(f'no quiz {quiz_id} found for user {user_id}')
 
 
-def new_quiz(quiz_info: dict, user_id: int) -> int:
+def new_quiz(name: str, user_id: int) -> int:
     """Creates a new quiz with questions and attempts based on the provided
     quiz_info dict."""
     with db.session.begin():
-        quiz = Quiz(name=quiz_info['name'], user_id=user_id)
+        quiz = Quiz(name=name, user_id=user_id)
         db.session.add(quiz)
-        for question_info in quiz_info['questions']:
-            # For convenience, the answer key is serialized to a string
-            question = Question(text=question_info['text'],
-                                answer_key=json.dumps(
-                                    question_info['answer_key']),
-                                quiz=quiz)
-            db.session.add(question)
-            for attempt_info in question_info['attempts']:
-                user = get_or_create(db.session, User,
-                                     username=attempt_info['username'])
-                attempt = Attempt(answer=attempt_info['answer'],
-                                  question=question,
-                                  user=user)
-                db.session.add(attempt)
     db.session.commit()
     return quiz.quiz_id
+
+
+def update_quiz(quiz_id: int, quiz_info: dict, user_id: int) -> None:
+    """Replace an existing quiz’s metadata, questions, and attempts.
+
+    The existing questions & attempts are deleted and recreated from the
+    supplied ``quiz_info`` structure.
+
+    Args:
+        quiz_id:    The ID of the quiz to update.
+        quiz_info:  Dict in the same format accepted by ``new_quiz``.
+        user_id:    The user performing the update; ensures ownership.
+    """
+    quiz = (
+        db.session.query(Quiz)
+        .filter_by(quiz_id=quiz_id, user_id=user_id)
+        .one_or_none()
+    )
+    if quiz is None:
+        raise NoResultFound("Quiz not found or access denied")
+
+    # Update quiz-level fields
+    if 'name' in quiz_info:
+        quiz.name = quiz_info['name']
+    if 'validation' in quiz_info:
+        quiz.validation = quiz_info['validation']
+
+    # Remove existing questions (cascade will delete attempts)
+    for question in list(quiz.questions):
+        db.session.delete(question)
+
+    # Add new questions & attempts
+    for question_info in quiz_info['questions']:
+        question = Question(
+            text=question_info['text'],
+            name=question_info['name'],
+            answer_key=json.dumps(question_info['answer_key']),
+            quiz=quiz,
+        )
+        db.session.add(question)
+
+        for attempt_info in question_info.get('attempts', []):
+            user = get_or_create(
+                db.session, User, username=attempt_info['username']
+            )
+            attempt = Attempt(
+                answer=attempt_info['answer'], question=question, user=user
+            )
+            db.session.add(attempt)
+    db.session.commit()
 
 
 def get_quiz(quiz_id: int, user_id: int) -> dict:
@@ -86,29 +121,28 @@ def list_quizzes(user_id: int) -> list:
 
 def update_attempts(attempts: list, user_id: int):
     """Updates attempts based on a list of attempt dicts."""
-    with db.session.begin():
-        for attempt_dict in attempts:
-            attempt_id = attempt_dict['attempt_id']
-            attempt = db.session.query(Attempt).get(attempt_id)
-            if not attempt:
-                logger.warning(f'Missing attempt: {attempt_id}')
-                continue
-            # Fetch the question associated with the attempt
-            question = attempt.question
-            if not question:
-                logger.warning(f'Missing question for attempt: {attempt_id}')
-                continue
-            # Fetch the quiz to which the question belongs
-            quiz = question.quiz
-            if not quiz:
-                logger.warning(f'Missing quiz for question ID: {question.question_id}')
-                continue
-            # Check if the current user owns the quiz
-            if quiz.user_id != user_id:
-                logger.warning(f'User {user_id} does not own quiz ID: {quiz.quiz_id}')
-                continue
-            # Update attempt details if the user owns the quiz
-            attempt.score = attempt_dict['score']
-            if attempt_dict['feedback'] is not None:
-                attempt.feedback = json.dumps(attempt_dict['feedback'])
+    for attempt_dict in attempts:
+        attempt_id = attempt_dict['attempt_id']
+        attempt = db.session.query(Attempt).get(attempt_id)
+        if not attempt:
+            logger.warning(f'Missing attempt: {attempt_id}')
+            continue
+        # Fetch the question associated with the attempt
+        question = attempt.question
+        if not question:
+            logger.warning(f'Missing question for attempt: {attempt_id}')
+            continue
+        # Fetch the quiz to which the question belongs
+        quiz = question.quiz
+        if not quiz:
+            logger.warning(f'Missing quiz for question ID: {question.question_id}')
+            continue
+        # Check if the current user owns the quiz
+        if quiz.user_id != user_id:
+            logger.warning(f'User {user_id} does not own quiz ID: {quiz.quiz_id}')
+            continue
+        # Update attempt details if the user owns the quiz
+        attempt.score = attempt_dict['score']
+        if attempt_dict['feedback'] is not None:
+            attempt.feedback = json.dumps(attempt_dict['feedback'])
     db.session.commit()

--- a/heymans/json_schemas.py
+++ b/heymans/json_schemas.py
@@ -9,6 +9,9 @@ QUIZ = {
     "name": {
       "type": "string"
     },
+    "validation": {
+      "type": ["string", "null"]
+    },
     "questions": {
       "type": "array",
       "items": {

--- a/heymans/routes/_quizzes.py
+++ b/heymans/routes/_quizzes.py
@@ -3,11 +3,8 @@ from flask import Blueprint, request, jsonify
 from flask_login import login_required, current_user
 from redis import Redis
 import logging
-from jsonschema import validate
-from jsonschema.exceptions import ValidationError
-from . import no_content, not_found, forbidden, success, invalid_json
-from .. import quizzes
-from .. import json_schemas
+from . import no_content, not_found, forbidden, success, invalid_json, error
+from .. import quizzes, convert
 from ..database.operations import quizzes as ops
 from ..database.models import NoResultFound
 
@@ -20,56 +17,184 @@ redis_client.set('grading_counter', -1)
 @quizzes_api_blueprint.route('/new', methods=['POST'])
 @login_required
 def new():
-    """Creates a new quiz. See json_schemas.QUIZ."""
-    try:
-        validate(instance=request.json, schema=json_schemas.QUIZ)
-    except ValidationError:
-        return invalid_json()
-    quiz_id = ops.new_quiz(request.json, current_user.get_id())
+    """Creates an empty quiz and returns its id.
+
+    JSON post data (example):
+        {"name": "quiz name"}
+    
+    Returns:
+        Status: OK (200)
+        JSON (example): {"quiz_id": 1}
+    """
+    name = request.json.get('name')
+    user_id = current_user.get_id()
+    quiz_id = ops.new_quiz(name, user_id)
     logger.info(f'created quiz: {quiz_id}')
     return jsonify({'quiz_id': quiz_id})
+
+
+@quizzes_api_blueprint.route('/add/questions/<int:quiz_id>', methods=['POST'])
+@login_required
+def add_questions(quiz_id):
+    """Adds questions to an existing quiz.
+    
+    JSON post data (example):
+        {"questions": "markdown questions and answer keys"}
+    
+    Returns:
+        Status: OK (200)
+        JSON (example): {"message": "success"}
+    """
+    if not request.is_json:
+        return invalid_json()
+    user_id = current_user.get_id()
+    questions = request.json.get('questions')
+    try:
+        quiz_info = convert.from_markdown_exam(questions, quiz_id)
+    except ValueError as e:
+        error_msg = f'failed to convert questions to json: {e}'
+        return error(error_msg)
+    try:
+        ops.update_quiz(quiz_id, quiz_info, user_id)
+    except NoResultFound:
+        return not_found()
+    except PermissionError:
+        return forbidden()
+    logger.info(f'added questions to quiz {quiz_id}')
+    return success()
+
+
+@quizzes_api_blueprint.route('/add/attempts/<int:quiz_id>', methods=['POST'])
+@login_required
+def add_attempts(quiz_id):
+    """Adds student attempts to an existing quiz.
+    
+    JSON post data (example):
+        {"attempts": "brightspace result data"}
+    
+    Returns:
+        Status: OK (200)
+        JSON (example): {"message": "success"}
+    """
+    if not request.is_json:
+        return invalid_json()
+    attempts = request.json.get('attempts')
+    user_id = current_user.get_id()
+    try:
+        quiz_info = ops.get_quiz(quiz_id, user_id)
+    except NoResultFound:
+        return not_found('Quiz not found')
+    # make sure any pending grades are committed
+    quizzes.quiz_grading_task_running(quiz_id, user_id)
+    try:
+        quiz_info = convert.merge_brightspace_attempts(quiz_info, attempts)
+    except Exception as e:
+        error_message = f'failed to merge attempts: {e}'
+        return error(error_message)
+    try:
+        ops.update_quiz(quiz_id, quiz_info, user_id)
+    except NoResultFound:
+        return not_found()
+    except PermissionError:
+        return forbidden()
+    logger.info(f'added attempts to quiz {quiz_id}')
+    return success()
 
 
 @quizzes_api_blueprint.route('/list')
 @login_required
 def list_():
-    """Gets a list of all quizzes."""
+    """Gets a list of all quizzes.
+    
+    Returns:
+        Status: OK (200)
+        JSON (example): [{"name": "quiz name", "quiz_id": 1}]
+    """
     return jsonify(ops.list_quizzes(current_user.get_id()))
     
     
 @quizzes_api_blueprint.route('/get/<int:quiz_id>')
 @login_required
 def get(quiz_id):
-    """Gets a single quiz."""
+    """Gets the results for a single quiz.
+    
+    Returns:
+        Status: OK (200)
+        JSON: see heymans.json_schemas.QUIZ
+    """
     user_id = current_user.get_id()
     # make sure any pending grades are committed
     quizzes.quiz_grading_task_running(quiz_id, user_id)
     try:
         return jsonify(ops.get_quiz(quiz_id, user_id))
-    except NoResultFound as e:
+    except NoResultFound:
+        return not_found('Quiz not found')
+        
+        
+@quizzes_api_blueprint.route('/export/brightspace/<int:quiz_id>')
+@login_required
+def export_brightspace(quiz_id):
+    """DUMMY IMPLEMENTATION
+    
+    Returns an export of the quiz questions in Brightspace format.
+    
+    Returns:
+        Status: OK (200)
+        JSON (example): {"text": "brightspace export"}
+    """    
+    
+@quizzes_api_blueprint.route('/state/<int:quiz_id>')
+@login_required
+def state(quiz_id):
+    """DUMMY IMPLEMENTATION
+    
+    Gets the state for a single quiz.
+    
+    0 - If there is no data
+    1 - If there are questions, but no attempts
+    2 - If there are ungraded attempts
+    3 - If there are graded attempts    
+    
+    Returns:
+        Status: OK (200)
+        JSON (example): {"state": 0}
+    """
+    user_id = current_user.get_id()
+    try:
+        return jsonify({"state" : quizzes.state(quiz_id, user_id)})
+    except NoResultFound:
         return not_found('Quiz not found')
     
     
-@quizzes_api_blueprint.route('/grading/start', methods=['POST'])
+@quizzes_api_blueprint.route('/grading/start/<int:quiz_id>', methods=['POST'])
 @login_required
-def grading_start():
-    """Start grading a single quiz. See json_schemas.GRADING_START. Grading
-    occurs in the background and needs to be polled through /api/grading/poll.
+def grading_start(quiz_id):
+    """Start grading a single quiz.
+    
+    Grading occurs in the background and needs to be polled through
+    /api/grading/poll/<quiz_id>.
+    
+    JSON post data (example):
+        {"model": "gpt-4.1"}
+    
+    Returns:
+        Status: OK (200)
+        JSON (example): {"message": "success"}
     """
-    try:
-        validate(instance=request.json, schema=json_schemas.GRADING_START)
-    except ValidationError as e:
-        return invalid_json()    
-    quiz_id = request.json['quiz_id']
+    model = request.json.get('model')
+
+    # Validate presence of required parameters
+    if not quiz_id or not model:
+        return invalid_json()  # 400 Bad Request
+
     logger.info(f'start grading quiz: {quiz_id}')
     try:
         quiz = ops.get_quiz(quiz_id, current_user.get_id())
     except NoResultFound:
-        return not_found('Quiz not found')    
-    model = request.json['model']
-    Process(target=quizzes.quiz_grading_task,
-            args=(quiz, model)).start()
-    return no_content()
+        return not_found('Quiz not found')
+
+    Process(target=quizzes.quiz_grading_task, args=(quiz, model)).start()
+    return success()
 
 
 @quizzes_api_blueprint.route('/grading/poll/<int:quiz_id>', methods=['GET'])
@@ -77,6 +202,10 @@ def grading_start():
 def grading_poll(quiz_id):
     """Checks whether grading of a quiz is in progress, done, needed, or 
     aborted.
+    
+    Returns:
+        Status: OK (200)
+        JSON (example): {"message": "needs_grading"}
     """
     user_id = current_user.get_id()
     if quizzes.quiz_grading_task_running(quiz_id, user_id):
@@ -105,10 +234,61 @@ def grading_delete(quiz_id):
     ops.delete_quiz(quiz_id, current_user.get_id())
     
 
-@quizzes_api_blueprint.route(
-    '/grading/push_to_learning_environment/<int:quiz_id>', methods=['GET'])
-def grading_push_to_learning_environment(quiz_id):
-    """Pushes the grades for a quiz to the learning environment. Currently
-    not implemented.
+# ---------------------------------------------------------------------------
+# Validation API end‑points
+# ---------------------------------------------------------------------------
+
+@quizzes_api_blueprint.route('/validation/start/<int:quiz_id>', methods=['POST'])
+@login_required
+def validation_start(quiz_id):
+    """Start validation of the quiz questions that have already been uploaded.
+    
+    The task runs in a background process (see quizzes.quiz_validation_task).
+    Results can be polled via /validation/poll.
+    
+    JSON post data (example):
+        {"model": "gpt-4.1"}
+    
+    Returns:
+        Status: OK (200)
+        JSON (example): {"message": "success"}
     """
-    return forbidden('Quiz does not exist in learning environment')
+    model = request.json.get('model')
+
+    # Validate presence of required parameter
+    if not model:
+        return invalid_json()  # 400 Bad Request
+
+    user_id = current_user.get_id()
+    logger.info(f'start validation for quiz: {quiz_id} using model: {model}')
+
+    try:
+        quiz = ops.get_quiz(quiz_id, user_id)
+    except NoResultFound:
+        return not_found('Quiz not found')
+
+    # Fire‑and‑forget background process
+    Process(target=quizzes.quiz_validation_task, args=(quiz, model)).start()
+    return no_content()
+
+
+@quizzes_api_blueprint.route('/validation/poll/<int:quiz_id>', methods=['GET'])
+@login_required
+def validation_poll(quiz_id):
+    """Poll the state of the validation task.
+    
+    Returns:
+        Status: OK (200)
+        JSON (example): {"message": "needs_validation"}
+    """
+    user_id = current_user.get_id()
+    if quizzes.quiz_validation_task_running(quiz_id, user_id):
+        return success(quizzes.VALIDATION_IN_PROGRESS)
+    try:
+        quiz = ops.get_quiz(quiz_id, user_id)
+    except NoResultFound:
+        return not_found('Quiz not found')
+    validation = quiz.get('validation')
+    if validation is None:
+        return success(quizzes.NEEDS_VALIDATION)
+    return success(quizzes.VALIDATION_DONE)

--- a/heymans/routes/_replies.py
+++ b/heymans/routes/_replies.py
@@ -1,5 +1,7 @@
 from http import HTTPStatus
 from flask import jsonify, make_response
+import logging
+logger = logging.getLogger('heymans')
 
 
 def not_found(msg):
@@ -24,8 +26,9 @@ def invalid_json():
     
     
 def error(msg):
+    logger.error(msg)
     return make_response({'error': msg}, HTTPStatus.BAD_REQUEST)
 
 
-def success(msg):
+def success(msg='success'):
     return jsonify({'message': msg})

--- a/tests/cheap/test_quizzes_api.py
+++ b/tests/cheap/test_quizzes_api.py
@@ -1,3 +1,4 @@
+import time
 from http import HTTPStatus
 from .test_app import BaseRoutesTestCase
 import jsonschema
@@ -5,25 +6,23 @@ from heymans import json_schemas
 from sigmund.model import _dummy_model
 
 
-DUMMY_QUIZ_DATA = {
-    'name': 'Quiz title',
-    'questions': [
-        {
-            'text': 'Who is the cutest bunny?',
-            'answer_key': ['Must state that the cutest bunny is Boef'],
-            'attempts': [{
-                'username': 's12345678',
-                'answer': 'The cutest bunny is Boef',
-            }, {
-                'username': 's12345678',
-                'answer': 'Don\'t know. :-('
-            }]
-        }
-    ]
-}
+DUMMY_QUIZ_DATA = '''# Cute bunny awareness exam
+
+## Cutest bunny
+
+Who is the cutest bunny?
+
+- Must state that the cutest bunny is Boef
+'''
+DUMMY_ATTEMPTS = '''Answer,Q Title,Username
+"The cutest bunny is Boef","Cutest bunny","s00000001"
+"I do not know :-(","Cutest bunny","s00000002"
+'''
+GRADING_RESPONSE = '[{"pass": true, "motivation": "great answer"}]'
+VALIDATION_RESPONSE = 'Amazing quiz. Just perfect.'
 
 
-class TestQuizzesAPI(BaseRoutesTestCase):
+class TestQuizzesGradingAPI(BaseRoutesTestCase):
         
     def test_basics(self):
         # Listing should be empty
@@ -31,45 +30,49 @@ class TestQuizzesAPI(BaseRoutesTestCase):
         assert response.status_code == HTTPStatus.OK
         assert len(response.json) == 0
         # Create a new quizz
-        response = self.client.post('/api/quizzes/new', json=DUMMY_QUIZ_DATA)
+        response = self.client.post('/api/quizzes/new', json={'name': 'Test'})
         assert response.status_code == HTTPStatus.OK
         assert response.json['quiz_id'] == 1
         # Check if the new quiz matches the dummy data that is was created with
         response = self.client.get('/api/quizzes/get/1')
         assert response.status_code == HTTPStatus.OK
-        assert self.compare_dicts_ignore_none(response.json, DUMMY_QUIZ_DATA)
         # Listing should now have one quiz
         response = self.client.get('/api/quizzes/list')
         assert response.status_code == HTTPStatus.OK
         assert len(response.json) == 1
+        print(response.json)
         
     def test_grading(self):
         
         def _dummy_grader(*args):
-            import time
             time.sleep(.1)
-            return '[{"pass": true, "motivation": "dummy feedback"}]'
+            return GRADING_RESPONSE
         
         _dummy_model.DummyModel.invoke = _dummy_grader
-        # Create a new quizz
-        response = self.client.post('/api/quizzes/new', json=DUMMY_QUIZ_DATA)
+        # Create a new quiz
+        response = self.client.post('/api/quizzes/new', json={'name': 'Test'})
         assert response.status_code == HTTPStatus.OK
         assert response.json['quiz_id'] == 1
+        # Add questions to quiz
+        response = self.client.post('/api/quizzes/add/questions/1',
+                                    json={'questions': DUMMY_QUIZ_DATA})
+        assert response.status_code == HTTPStatus.OK
+        # Add attempts to quiz
+        response = self.client.post('/api/quizzes/add/attempts/1',
+                                    json={'attempts': DUMMY_ATTEMPTS})
+        assert response.status_code == HTTPStatus.OK
         # Check that the quiz needs grading
         response = self.client.get('/api/quizzes/grading/poll/1')
         assert response.status_code == HTTPStatus.OK
         assert response.json['message'] == 'needs_grading'
         # Start grading
-        response = self.client.post('/api/quizzes/grading/start', json={
-            'quiz_id': 1,
-            'model': 'dummy'
-        })
-        assert response.status_code == HTTPStatus.NO_CONTENT
+        response = self.client.post('/api/quizzes/grading/start/1',
+                                    json={'model': 'dummy'})
+        assert response.status_code == HTTPStatus.OK
         # Grading should now be in progress
         response = self.client.get('/api/quizzes/grading/poll/1')
         assert response.status_code == HTTPStatus.OK
         assert response.json['message'] == 'grading_in_progress'
-        import time
         time.sleep(1)
         # Grading should now be done
         response = self.client.get('/api/quizzes/grading/poll/1')
@@ -79,6 +82,42 @@ class TestQuizzesAPI(BaseRoutesTestCase):
         assert response.status_code == HTTPStatus.OK
         for attempt in response.json['questions'][0]['attempts']:
             assert attempt['score'] == 1
-            assert attempt['feedback'][0]['motivation'] == 'dummy feedback'
+            assert attempt['feedback'][0]['motivation'] == 'great answer'
         jsonschema.validate(response.json, json_schemas.QUIZ)
-        
+
+    def test_validation(self):
+            
+        # Install dummy validator
+        def _dummy_validator(*args):
+            time.sleep(.1)            
+            return VALIDATION_RESPONSE
+        _dummy_model.DummyModel.invoke = _dummy_validator        
+        # Create a new quiz
+        response = self.client.post('/api/quizzes/new', json={'name': 'Test'})
+        assert response.status_code == HTTPStatus.OK
+        assert response.json['quiz_id'] == 1
+        # Add questions to quiz
+        response = self.client.post('/api/quizzes/add/questions/1',
+                                    json={"questions": DUMMY_QUIZ_DATA})
+        assert response.status_code == HTTPStatus.OK        
+        # Check that the quiz needs validation
+        response = self.client.get('/api/quizzes/validation/poll/1')
+        assert response.status_code == HTTPStatus.OK
+        assert response.json['message'] == 'needs_validation'
+        # Start validation
+        response = self.client.post('/api/quizzes/validation/start/1',
+                                    json={'model': 'dummy'})
+        assert response.status_code == HTTPStatus.NO_CONTENT
+        # Validation should now be in progress
+        response = self.client.get('/api/quizzes/validation/poll/1')
+        assert response.status_code == HTTPStatus.OK
+        assert response.json['message'] == 'validation_in_progress'
+        time.sleep(1)
+        # Validation should now be done
+        response = self.client.get('/api/quizzes/validation/poll/1')
+        assert response.status_code == HTTPStatus.OK
+        assert response.json['message'] == 'validation_done'
+        response = self.client.get('/api/quizzes/get/1')
+        assert response.status_code == HTTPStatus.OK
+        assert VALIDATION_RESPONSE in response.json['validation']
+        jsonschema.validate(response.json, json_schemas.QUIZ)


### PR DESCRIPTION
This is a rough first implementation of the quizzes API as required to implement the quizzes front-end. All the end-points are implemented, although two of them (state and export/brightspace) are dummy implementations. For documentation, see the test_quizzes_api unit test and the end-point specification that is shown when you start the server.