### PR TITLE
Quiz fe flow

### DIFF
--- a/heymans/database/operations/quizzes.py
+++ b/heymans/database/operations/quizzes.py
@@ -59,6 +59,12 @@ def update_quiz(quiz_id: int, quiz_info: dict, user_id: int) -> None:
             quiz.name = quiz_info['name']
         if 'validation' in quiz_info:
             quiz.validation = quiz_info['validation']
+        else:
+            quiz.validation = None
+        if 'qualitative_error_analysis' in quiz_info:
+            quiz.qualitative_error_analysis = quiz_info['qualitative_error_analysis']
+        else: 
+            quiz.qualitative_error_analysis = None
 
         # Remove existing questions (cascade deletes attempts)
         for question in list(quiz.questions):

--- a/heymans/static/css/components.css
+++ b/heymans/static/css/components.css
@@ -265,6 +265,59 @@
   font-weight: bold;
 }
 
+.explanation-box {
+  border: 1px dashed #ccc;
+  background-color: #f9f9f9;
+  color: #444;
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+.explanation-box a {
+  color: #337ab7;
+  text-decoration: underline;
+}
+
+/* Generic inline button label style */
+.button-label {
+  display: inline-block;
+  margin: 1px 0;               /* <- Add vertical spacing */
+  padding: 1px 8px;
+  border-radius: 5px;
+  font-size: 14px;
+  font-family: inherit;
+  font-weight: 500;
+  cursor: default;
+  border: 2px solid transparent;
+  transition: background-color 0.1s, color 0.1s;
+}
+
+/* Match regular button */
+.regular-button-label {
+  background-color: #0095e9;
+  color: white;
+  border-color: #0095e9;
+}
+.regular-button-label:hover {
+  background-color: white;
+  color: #0095e9;
+}
+
+/* Match LLM button */
+.llm-button-label {
+  background-color: #006300;
+  color: white;
+  border-color: #006300;
+}
+.llm-button-label:hover {
+  background-color: white;
+  color: #006300;
+}
+
+
+
 /*For me, just to make debg info formatted reasonably.*/
 .debuginfo {
   max-width: 800px;
@@ -277,4 +330,6 @@
   line-height: 1.4;
   white-space: pre-wrap;
 }
+
+
 

--- a/heymans/static/css/components.css
+++ b/heymans/static/css/components.css
@@ -125,6 +125,36 @@
   cursor: not-allowed; /* Change cursor to not-allowed */
 }
 
+/*spinners shown next to buttons*/
+.spinner-gap {
+  display: inline-block;
+  width: 18px;
+  height: 16px;
+  vertical-align: middle;
+}
+
+.spinner {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  margin-right: 2px; 
+  border: 2px solid #ccc;
+  border-top: 2px solid #888;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+  vertical-align: middle;
+  position: relative;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+
+
+
 /* Styling for overlay notifications */
 .overlay {
     background-color: rgba(0, 0, 0, 0.5);
@@ -315,8 +345,6 @@
   background-color: white;
   color: #006300;
 }
-
-
 
 /*For me, just to make debg info formatted reasonably.*/
 .debuginfo {

--- a/heymans/static/css/components.css
+++ b/heymans/static/css/components.css
@@ -33,6 +33,21 @@
 .top-menu li { display: inline-block; /* Adjust as needed */ }
 .top-menu a { text-decoration: none; color: white; padding: 0 15px; /* Add padding to increase clickable area */ }
 
+/* Default nav link styling (active/normal) */
+.nav-link {
+  text-decoration: none;
+  color: white;
+  padding: 0 15px;
+  font-weight: bold;
+}
+
+/* Disabled styling only applies to links with .disabled class */
+.nav-link.disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  border-bottom: none;
+}
+
 .divider {
   background-color: #FFFFFF; /* White background */
   height: 5px; /* Thinner height for the divider */

--- a/heymans/static/css/layout.css
+++ b/heymans/static/css/layout.css
@@ -100,4 +100,5 @@ html, body {
     gap: 10px;
     justify-content: start;
     flex-wrap: wrap;
+    align-items: center;
 }

--- a/heymans/static/js/vue/quiz.js
+++ b/heymans/static/js/vue/quiz.js
@@ -239,7 +239,7 @@ const app = Vue.createApp({
             body: JSON.stringify({ questions: markdownContent }),
           });
 
-          // TODO handle different errors for add/questions?
+          // handle different errors for add/questions?
           if (!response.ok) {
             throw new Error(`Upload failed with status ${response.status}`);
           }
@@ -255,6 +255,7 @@ const app = Vue.createApp({
           await this.getQuizState(this.quizSelected);
           // validation report cleared for this quiz:
           this.validationReport = null
+          this.analysisReport = null
         } catch (err) {
           console.error("Error uploading quiz:", err);
           this.showOverlay(`Upload failed`, `${err.message}`);
@@ -268,6 +269,14 @@ const app = Vue.createApp({
 
     // kick off validation:
     async validateQuiz() {
+      // clear old report from view:
+      this.$nextTick(() => {
+        setTimeout(() => {
+          this.validationReport = null;
+          this.analysisReport = null;
+        }, 0);
+      });
+
       try {
         const response = await fetch(`/api/quizzes/validation/start/${this.quizSelected}`, {
           method: "POST",
@@ -384,6 +393,12 @@ const app = Vue.createApp({
 
     // Kick off grading
     async gradeQuiz() {
+      // clear old report from view:
+      this.$nextTick(() => {
+        setTimeout(() => {
+          this.analysisReport = null;
+        }, 0);
+      });
       try {
         const response = await fetch(`/api/quizzes/grading/start/${this.quizSelected}`, {
           method: "POST",
@@ -453,12 +468,7 @@ const app = Vue.createApp({
           table += `| ${question.name} | ${attempt.username} | ${attempt.score ?? '-'} |\n`;
         }
       }
-      console.log(table)
-
       this.gradingReport = table;
-      this.$nextTick(() => {
-        console.log("Grading report should now be rendered.");
-      });
     },
 
     // export quiz to a format Brightspace likes

--- a/heymans/static/js/vue/quiz.js
+++ b/heymans/static/js/vue/quiz.js
@@ -61,7 +61,6 @@ const app = Vue.createApp({
       // and remove grading report (until re-rendered)
       this.gradingReport = null;
 
-
       // now set panels using this state.
       switch (this.quizState) {
         case 'empty':
@@ -86,12 +85,11 @@ const app = Vue.createApp({
         this.gradingStatus = '';
         await this.pollValidationStatus()
         await this.pollGradingStatus()
-        // after polling, check again?
+        // after polling, state might have changed. 
         await this.getQuizState(quiz_id);
       }
 
-
-      // ask the server for quizData and status.
+      // Now that we have the state; ask the server for what data to show.
       try {
         const response = await fetch(`/api/quizzes/get/${quiz_id}`);
         
@@ -501,8 +499,8 @@ const app = Vue.createApp({
   computed: {
     quizStateLabel() {
       const labels = {
-        empty: "This quiz is empty. Upload a quiz file to add (new) questions.",
-        has_questions: "Questions have been uploaded. Validate (recommended!) before administering quiz.",
+        empty: "This quiz is empty. Upload a quiz file to get started.",
+        has_questions: "Questions have been uploaded. Validate (recommended) before administering quiz.",
         has_attempts: "Attempts have been uploaded. Ready to grade this quiz!",
         has_scores: "Grading complete! Look at scores & analyses next."
       };
@@ -511,9 +509,9 @@ const app = Vue.createApp({
 
     validationMessage() {
       const label = {
-        needs_validation: "Quiz has not been validated",
-        validation_in_progress: "Validation is currently running.",
-        validation_done: "Validation report has been generated.",
+        needs_validation: "Quiz has not yet been validated",
+        validation_in_progress: "Heymans is currently validating this quiz.",
+        validation_done: "Validation done! Validation report shown below.",
       };
       return label[this.validationStatus] || "Validation status unknown.";
     },
@@ -524,7 +522,7 @@ const app = Vue.createApp({
         grading_in_progress: "Heymans is currently grading this quiz.",
         grading_error: "Heymans encountered some errors during grading; Results are probably incomplete. My suggestion is to run it again",
         grading_needs_commit: "Nearly done grading.",
-        grading_done: "Grading is done.",
+        grading_done: "Grading done! Error analysis report shown below.",
       };
       return label[this.gradingStatus] || "Grading status unknown.";
     },
@@ -556,9 +554,9 @@ const app = Vue.createApp({
       if (this.quizState == 'has_attempts'){
         return false
       }
-      if (this.quizState == 'has_scores'){
-        return false
-      }
+      // if (this.quizState == 'has_scores'){
+      //   return false
+      // }
       if (this.validationStatus == 'validation_in_progress' ){
         return false
       }

--- a/heymans/static/js/vue/quiz.js
+++ b/heymans/static/js/vue/quiz.js
@@ -18,6 +18,12 @@ const app = Vue.createApp({
       gradingReport: null,
 
       analysisReport: null,
+
+      spinValidate: false,
+      spinGrade   : false,
+      spinExportQuiz: false,
+      spinExportScores: false,
+      spinExportFeedback: false,
     };
   },
   created() {
@@ -402,6 +408,8 @@ const app = Vue.createApp({
 
     // export quiz to a format Brightspace likes
     async exportScores(){
+      this.spinExportScores = true;
+
       const safeName = (this.quizName || "scores").replace(/\s+/g, "_");
       try {
         await this.downloadFile({
@@ -416,10 +424,14 @@ const app = Vue.createApp({
         });
       } catch (err) {
         this.showOverlay("Export failed", err.message);
+      } finally {
+        this.spinExportScores = false;
       }
     },
     
     async exportAnalysis(){
+      this.spinExportFeedback = true;
+
       const safeName = (this.quizName || "feedback").replace(/\s+/g, "_");
       try {
         await this.downloadFile({
@@ -435,6 +447,8 @@ const app = Vue.createApp({
         });
       } catch (err) {
         this.showOverlay("Export failed", err.message);
+      } finally {
+        this.spinExportFeedback = false;
       }
     },
 
@@ -626,4 +640,18 @@ app.component('markdown-renderer', {
   },
   template: `<div class="markdown-rendered" v-html="rendered"></div>`
 });
+
+// Spinner Placeholder Component
+app.component('spinner-gap', {
+  props: {
+    active: { type: Boolean, default: false }
+  },
+  template: `
+    <span class="spinner-gap">
+      <span v-if="active" class="spinner"></span>
+    </span>
+  `
+});
+
+
 app.mount('#app');

--- a/heymans/templates/partials/_quiz_content.html
+++ b/heymans/templates/partials/_quiz_content.html
@@ -38,6 +38,27 @@
       </div>
       <transition name="collapse">
         <div class="card-body" v-show="showCreatePanel">
+          <div class="explanation-box">
+          To prepare a quiz for automated grading:
+          <ol>
+            <li>Create a quiz file. This file defines the quiz title, questions and answer key. The format is
+              <a href="https://heymansai.rug.nl/instructions" target="_blank">explained here</a>.
+            </li>
+            <li>Use <span class="button-label regular-button-label">Upload Quiz</span> to upload this file.</li>
+            <li>Use <span class="button-label llm-button-label">Validate Quiz</span> (<em>Optional</em>) to let Heymans assess the wording of your questions and answer key. After a few minutes, a validation report will appear below, with suggestions to improve the quiz and resolve ambiguities.
+            </li>
+            <li> Use <span class="button-label regular-button-label">Export Quiz</span> to download the quiz as a csv file in a Brightspace-compliant format.</li>
+            <li> On Brightspace, create a new quiz (or edit an existing quiz). Upload your exported file using <em>Add existing → Upload a file</em>.
+            </li>
+            <li>Your exam is now ready to be administered!</li>
+          </ol>
+          <em>N.B.:</em>
+          <ul>
+            <li>Uploading a new quiz file will <u>  overwrite</u> any existing quiz data, including the validation report.</li>
+          <li>The quiz definition cannot be changed once your quiz is administered and attempts have been uploaded (below).</li>
+          <li>Heymans' validation report is usually very detailed. Suggestions might not be applicable in the context of your course.</li>
+        </ul>
+        </div>
           <div class="button-row">
           <!-- Triggering file upload event -->
           <button class="regular-button" @click="triggerFileInput" :disabled="!buttonActiveUpload">
@@ -73,6 +94,23 @@
       </div>
       <transition name="collapse">
         <div class="card-body" v-show="showGradePanel && cardActiveGrade">
+          <div class="explanation-box">
+          After you have administered the exam:
+          <ol>
+            <li>Download students' attempts on Brightspace via <em>Assessment → Grade (available under the menu next to your quiz) -> Export to CSV</em>, and download the export file when it's ready </li>
+            <li>Use <span class="button-label regular-button-label">Upload Attempts</span> to upload this file.</li>
+            <li>Use <span class="button-label llm-button-label">Start Grading</span>. This will take time, dependent on the number of questions and attempts.
+            </li>
+            <li>Once grading is completed, an error analysis report is generated: per question, Heymans assesses how each question has been scored, and gives a qualitative assessment whether this assessment seems fair.</li>
+            <li>Move on to the final stage (below) to evaluate and export these results.</li>
+          </ol>
+          <em>N.B.:</em><br> 
+          <ul>
+            <li>Uploading a new attempts file will <u>erase</u> any existing grading results, including the scores and analysis.</li>
+            <li>Similar to the validation report, the error report is usually very detailed. Suggestions might not be applicable in the context of your course. </li>
+        </ul>
+        </div>
+
 
           <div class="button-row">
           <!-- Triggering file upload event -->
@@ -94,7 +132,8 @@
             {{ gradingMessage }}
           </p>
 
-          <markdown-renderer v-if="gradingReport" :content="gradingReport" />
+          <!-- <markdown-renderer v-if="gradingReport" :content="gradingReport" /> -->
+          <markdown-renderer v-if="analysisReport" :content="analysisReport" />
 
         </div>
       </transition>
@@ -110,7 +149,13 @@
       </div>
       <transition name="collapse">
         <div class="card-body" v-show="showAnalyzePanel && cardActiveAnalyze">
-          
+          <div class="explanation-box">
+          Now that the exam has been graded, you can:
+          <ul>
+            <li>Use <span class="button-label regular-button-label">Export Scores</span> to download a csv file with scores per student in a Brightspace-compliant format.</li>
+            <li>Use <span class="button-label regular-button-label">Export Feedback</span> to download a zip file with per-student feedback reports. These reports can be emailed to students individually, or referenced in their exam inspection</li>
+        </ul>
+        </div>
           <div class="button-row">
             <button class="regular-button" @click="exportScores" :disabled="!(gradingStatus=='grading_done')">
               Export Scores
@@ -121,11 +166,8 @@
           </div>
 
           <p class="heymans-msg">
-            Your quiz has been graded. See a report for the error analysis below.
+            Your quiz has been graded. Download the scores and/or individualized feedback here.
           </p>
-
-        <markdown-renderer v-if="analysisReport" :content="analysisReport" />
-
         </div>
       </transition>
     </div>

--- a/heymans/templates/partials/_quiz_content.html
+++ b/heymans/templates/partials/_quiz_content.html
@@ -76,7 +76,7 @@
 
           <div class="button-row">
           <!-- Triggering file upload event -->
-            <button class="regular-button" @click="triggerAttemptsInput"> Upload Attempts </button>
+            <button class="regular-button" @click="triggerAttemptsInput" :disabled ="!buttonActiveAttempts"> Upload Attempts </button>
             <input
               ref="attemptsInput"
               type="file"
@@ -146,14 +146,13 @@
       </div>
     </div>
 
-    <div class="debuginfo">
+    <!-- <div class="debuginfo">
       <pre>{{ quizSelected }}</pre>
       <pre>cardActiveCreate: {{ cardActiveCreate }}</pre>
       <pre>quizState: {{ quizState }}</pre>
       <pre>gradingStatus: {{ gradingStatus }}</pre>
-      <pre> "===" </pre>
       <pre>{{ fullQuizData }}</pre>
-    </div>
+    </div> -->
 
   </div>  <!-- end main-content -->
 

--- a/heymans/templates/partials/_quiz_content.html
+++ b/heymans/templates/partials/_quiz_content.html
@@ -189,13 +189,13 @@
       </div>
     </div>
 
-    <!-- <div class="debuginfo">
+    <div class="debuginfo">
       <pre>{{ quizSelected }}</pre>
       <pre>cardActiveCreate: {{ cardActiveCreate }}</pre>
       <pre>quizState: {{ quizState }}</pre>
       <pre>gradingStatus: {{ gradingStatus }}</pre>
       <pre>{{ fullQuizData }}</pre>
-    </div> -->
+    </div>
 
   </div>  <!-- end main-content -->
 

--- a/heymans/templates/partials/_quiz_content.html
+++ b/heymans/templates/partials/_quiz_content.html
@@ -153,7 +153,8 @@
           Now that the exam has been graded, you can:
           <ul>
             <li>Use <span class="button-label regular-button-label">Export Scores</span> to download a csv file with scores per student in a Brightspace-compliant format.</li>
-            <li>Use <span class="button-label regular-button-label">Export Feedback</span> to download a zip file with per-student feedback reports. These reports can be emailed to students individually, or referenced in their exam inspection</li>
+            <li>Use <span class="button-label regular-button-label">Export Feedback</span> to download a zip file with per-student feedback reports. Generating this could take a few minutes.</li>
+            <li>Feedback reports can be emailed to students directly, or referenced in an exam inspection</li>
         </ul>
         </div>
           <div class="button-row">
@@ -161,8 +162,9 @@
               Export Scores
             </button>
             <button class="regular-button" @click="exportAnalysis" :disabled="!cardActiveAnalyze">
-              Export Feedack
+              Export Feedback
             </button>
+            <spinner-gap :active="spinExportFeedback"></spinner-gap>
           </div>
 
           <p class="heymans-msg">
@@ -172,12 +174,12 @@
       </transition>
     </div>
 
-      <!-- Button to delete quiz: -->
-      <div class="button-row" style="justify-content: flex-end;"  v-if="quizSelected">
-        <button class="regular-button" @click="deleteQuiz" :disabled="!quizSelected">
-          Delete quiz
-        </button>
-      </div>
+    <!-- Button to delete quiz: -->
+    <div class="button-row" style="justify-content: flex-end;"  v-if="quizSelected">
+      <button class="regular-button" @click="deleteQuiz" :disabled="!quizSelected">
+        Delete quiz
+      </button>
+    </div>
 
     <!-- Overlay to show errors: -->
     <div id="overlay" class="overlay">

--- a/heymans/templates/partials/_quiz_content.html
+++ b/heymans/templates/partials/_quiz_content.html
@@ -42,7 +42,7 @@
           To prepare a quiz for automated grading:
           <ol>
             <li>Create a quiz file. This file defines the quiz title, questions and answer key. The format is
-              <a href="https://heymansai.rug.nl/instructions" target="_blank">explained here</a>.
+              <a href="https://docs.google.com/document/d/1uUg41KLDX7WaqRNs79GyJJYdZySLtIG5Wr1LCEbzysM/edit?usp=sharing" target="_blank" rel="noopener noreferrer">explained here</a>.
             </li>
             <li>Use <span class="button-label regular-button-label">Upload Quiz</span> to upload this file.</li>
             <li>Use <span class="button-label llm-button-label">Validate Quiz</span> (<em>Optional</em>) to let Heymans assess the wording of your questions and answer key. After a few minutes, a validation report will appear below, with suggestions to improve the quiz and resolve ambiguities.
@@ -54,8 +54,7 @@
           </ol>
           <em>N.B.:</em>
           <ul>
-            <li>Uploading a new quiz file will <u>  overwrite</u> any existing quiz data, including the validation report.</li>
-          <li>The quiz definition cannot be changed once your quiz is administered and attempts have been uploaded (below).</li>
+            <li>Uploading a new quiz file will <u>overwrite</u> any existing quiz data, including the validation report.</li>
           <li>Heymans' validation report is usually very detailed. Suggestions might not be applicable in the context of your course.</li>
         </ul>
         </div>

--- a/heymans/templates/partials/banner.html
+++ b/heymans/templates/partials/banner.html
@@ -21,9 +21,9 @@
 <!-- top menu with functionality -->
 <div class="top-menu">
   <ul>
-    <li><a href="#"> Quiz Grading </a></li>
-    <li><a href="#"> Assignments </a></li>
-    <li><a href="#"> Knowledge Base </a></li>
+    <li><a href="{{ url_for('app.quiz') }}" class="nav-link">Quiz Grading</a></li>
+    <li><a href="#" class="nav-link disabled" @click.prevent>Assignments</a></li>
+    <li><a href="#" class="nav-link disabled" @click.prevent>Knowledge Base</a></li>
   </ul>
 </div>
 <div class="divider"></div>


### PR DESCRIPTION
Steps to improve grading frontend workflow
* reactivity (spinners, timed polling of grading/validation
* State management; reports now render immediately, without the need for refresh
* User guidance (instructions are provided per card, as suggested in #26 ). 
* [6f924d6](https://github.com/rug-gmw/heymans/pull/28/commits/6f924d6aed282970a8ef90d71a549bb619e09f1e) updates backend to match workflow instructions; now remove old validation report/grading report when a new quiz file or attempts file get uploaded. 
N.B. grading_status still remains at `grading_done` when a new attempts file gets uploaded, rather than update to `needs_grading`
