### PR TITLE
Add end-point for difficulty and discrimination

### DIFF
--- a/heymans/__init__.py
+++ b/heymans/__init__.py
@@ -1,3 +1,3 @@
 """AI tutor for education"""
 
-__version__ = '0.1.2'
+__version__ = '0.2.0'

--- a/heymans/report.py
+++ b/heymans/report.py
@@ -108,7 +108,10 @@ def analyze_difficulty_and_discrimination(
         mean_student_scores = np.mean(other_scores, axis=0)
         row.question = question['name']
         row.question_nr = j + 1
-        row.rir = spearmanr(scores_norm, mean_student_scores).statistic
+        try:
+            row.rir = spearmanr(scores_norm, mean_student_scores).statistic
+        except ValueError:
+            row.rir = np.nan
         row.m = np.mean(scores_norm)
         row.sd = np.std(scores_norm)
     _write_dst(dm, dst)

--- a/tests/cheap/test_quizzes_api.py
+++ b/tests/cheap/test_quizzes_api.py
@@ -97,6 +97,11 @@ class TestQuizzesGradingAPI(BaseRoutesTestCase):
         # Export grades
         response = self.client.post('/api/quizzes/export/grades/1')
         assert response.status_code == HTTPStatus.OK
+        # Export grades
+        response = self.client.get(
+            '/api/quizzes/export/difficulty_and_discrimination/1')
+        assert response.status_code == HTTPStatus.OK
+        assert 'content' in response.json
         # Export individual feedback
         response = self.client.post('/api/quizzes/export/feedback/1')
         assert response.content_type == 'application/zip'


### PR DESCRIPTION
This implements `/export/difficulty_and_discrimination/<int:quiz_id>`. It returns `csv`-formatted text content, so not directly a figure. I think it's best to use a simple client-side plotting library to draw the figure, and then also offer the data as a `csv` download.