### PR TITLE
Show Chat logs to teachers

### DIFF
--- a/heymans/database/operations/interactive_quizzes.py
+++ b/heymans/database/operations/interactive_quizzes.py
@@ -202,6 +202,67 @@ def finished(interactive_quiz_id: int, username: str) -> int:
         return count
 
 
+def get_interactive_quiz_logs(interactive_quiz_id: int,
+                              owner_user_id: str | int,
+                              student_username: str) -> Dict[str, Any]:
+    """Return all logged conversations/messages for one student in one quiz.
+
+    Semantics:
+      - owner_user_id: the (authenticated) quiz owner
+      - student_username: the student identifier saved on conversations
+    """
+    student_username = (student_username or "").strip()
+    if not student_username:
+        raise ValueError("student_username is required")
+
+    with db.session.begin():
+        quiz = _get_quiz(interactive_quiz_id, owner_user_id)
+        conversation_ids = [
+            row[0]
+            for row in (
+                db.session.query(InteractiveQuizConversation.conversation_id)
+                .filter(
+                    InteractiveQuizConversation.interactive_quiz_id == interactive_quiz_id,
+                    InteractiveQuizConversation.username == student_username,
+                )
+                .order_by(InteractiveQuizConversation.conversation_id.asc())
+                .all()
+            )
+        ]
+        quiz_name = quiz.name
+
+    conversations: List[Dict[str, Any]] = []
+    for conversation_id in conversation_ids:
+        conversation = get_interactive_quiz_conversation(conversation_id)
+        messages = sorted(
+            conversation.get("messages", []),
+            key=lambda message: message["message_id"],
+        )
+        conversations.append({
+            "conversation_id": conversation["conversation_id"],
+            "finished": conversation["finished"],
+            "messages": [
+                {
+                    "message_id": message["message_id"],
+                    "role": _map_message_type_to_role(message["message_type"]),
+                    "text": message["text"],
+                }
+                for message in messages
+            ],
+        })
+
+    finished_count = sum(1 for conversation in conversations if conversation["finished"])
+    return {
+        "interactive_quiz_id": interactive_quiz_id,
+        "quiz_name": quiz_name,
+        "owner_user_id": owner_user_id,
+        "student_username": student_username,
+        "started_count": len(conversations),
+        "finished_count": finished_count,
+        "conversations": conversations,
+    }
+
+
 ## Helpers
 
 
@@ -227,3 +288,8 @@ def _get_conversation(conversation_id: int) -> InteractiveQuizConversation:
     if conversation is None:
         raise ValueError(f"InteractiveQuizConversation {conversation_id} does not exist")
     return conversation
+
+
+def _map_message_type_to_role(message_type: str) -> str:
+    """Map DB message type values to frontend role values."""
+    return "assistant" if message_type == "ai" else "user"

--- a/heymans/database/operations/interactive_quizzes.py
+++ b/heymans/database/operations/interactive_quizzes.py
@@ -18,7 +18,6 @@ MAX_SAFE_JS_INT = 2 ** 53 - 1
 interactive_quiz_schema = InteractiveQuizSchema()
 interactive_quiz_conversation_schema = InteractiveQuizConversationSchema()
 
-
 def new_interactive_quiz(name: str, document_id: int, user_id: int,
                          public: bool = False) -> int:
     """Adds a new interactive quiz to the database and returns its ID."""
@@ -238,17 +237,18 @@ def get_interactive_quiz_logs(interactive_quiz_id: int,
             conversation.get("messages", []),
             key=lambda message: message["message_id"],
         )
+        normalized_messages = [
+            {
+                "message_id": message["message_id"],
+                "role": _map_message_type_to_role(message["message_type"]),
+                "text": message["text"],
+            }
+            for message in messages
+        ]
         conversations.append({
             "conversation_id": conversation["conversation_id"],
             "finished": conversation["finished"],
-            "messages": [
-                {
-                    "message_id": message["message_id"],
-                    "role": _map_message_type_to_role(message["message_type"]),
-                    "text": message["text"],
-                }
-                for message in messages
-            ],
+            "messages": _strip_hidden_initial_user_message(normalized_messages),
         })
 
     finished_count = sum(1 for conversation in conversations if conversation["finished"])
@@ -293,3 +293,18 @@ def _get_conversation(conversation_id: int) -> InteractiveQuizConversation:
 def _map_message_type_to_role(message_type: str) -> str:
     """Map DB message type values to frontend role values."""
     return "assistant" if message_type == "ai" else "user"
+
+
+def _strip_hidden_initial_user_message(
+    messages: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Match session UI behavior by hiding the synthetic opening user message."""
+    if not messages:
+        return messages
+    first_message = messages[0]
+    if (
+        first_message.get("role") == "user"
+        and (first_message.get("text") or "").strip() == "Ask me anything!"
+    ):
+        return messages[1:]
+    return messages

--- a/heymans/routes/_app.py
+++ b/heymans/routes/_app.py
@@ -65,3 +65,20 @@ def iquiz():
         return redirect(url_for('app.login'))
     return render_template('iquiz.html', showDebugInfo=config.show_debug_info,
                            version=__version__)
+
+
+@app_blueprint.route('/iquiz/logs/<int:interactive_quiz_id>', methods=['GET'])
+def iquiz_logs(interactive_quiz_id):
+    """Returns a quiz logs page."""
+    if not current_user.is_authenticated:
+        return redirect(url_for('app.login'))
+
+    username = request.args.get('username', '').strip()
+    return render_template(
+        'iquiz_sess.html',
+        interactive_quiz_id=interactive_quiz_id,
+        username=username,
+        iquiz_mode='logs',
+        log_username=username,
+        version=__version__,
+    )

--- a/heymans/routes/_interactive_quizzes.py
+++ b/heymans/routes/_interactive_quizzes.py
@@ -159,6 +159,35 @@ def name(interactive_quiz_id):
     return jsonify({"name": iq['name']})
 
 
+@iq_api_blueprint.route('/logs/<int:interactive_quiz_id>/<string:username>')
+@login_required
+def logs(interactive_quiz_id, username):
+    """Retrieve all chat logs for one student in one interactive quiz.
+
+    Returns
+    -------
+    200 OK
+    404 Not Found
+    """
+    user_id = current_user.get_id()
+    try:
+        # Explicit owner/access validation
+        iq_ops.get_interactive_quiz(interactive_quiz_id, user_id)
+        logs = iq_ops.get_interactive_quiz_logs(
+            interactive_quiz_id=interactive_quiz_id,
+            owner_user_id=user_id,
+            student_username=username,
+        )
+    except (NoResultFound, ValueError, PermissionError) as e:
+        return not_found(str(e))
+
+    if not logs['conversations']:
+        return not_found(
+            f"No conversations found for username '{username}' in quiz {interactive_quiz_id}"
+        )
+    return jsonify(logs)
+
+
 @iq_api_blueprint.route('/delete/<int:interactive_quiz_id>',
                         methods=['DELETE'])
 @login_required

--- a/heymans/routes/_public.py
+++ b/heymans/routes/_public.py
@@ -18,5 +18,7 @@ def iquiz_session(interactive_quiz_id):
         'iquiz_sess.html',
         interactive_quiz_id=interactive_quiz_id,
         username=username,
+        iquiz_mode='chat',
+        log_username='',
         version=__version__,
     )

--- a/heymans/static/css/chat.css
+++ b/heymans/static/css/chat.css
@@ -183,6 +183,23 @@
   padding: 8px 12px;
 }
 
+.chat-logs-container {
+  height: auto;
+  max-width: 900px;
+}
+
+.chat-conversation-block {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.chat-log-window {
+  flex: 0 0 auto;
+  min-height: 180px;
+  max-height: 340px;
+}
+
 @media (max-width: 1100px) {
   .header-banner {
     padding-left: 2rem;
@@ -232,6 +249,10 @@
     height: calc(100dvh - 112px);
     max-width: none;
     gap: 6px;
+  }
+
+  .chat-logs-container {
+    height: auto;
   }
 
   .chat-topline {
@@ -332,6 +353,10 @@
   .chat-container {
     height: calc(100dvh - 102px);
     gap: 5px;
+  }
+
+  .chat-logs-container {
+    height: auto;
   }
 
   .chat-top-left h2 {

--- a/heymans/static/css/chat.css
+++ b/heymans/static/css/chat.css
@@ -194,10 +194,22 @@
   gap: 4px;
 }
 
+.chat-conversation-block.with-divider {
+  border-top: 1px solid #000;
+  padding-top: 12px;
+  margin-top: 8px;
+}
+
 .chat-log-window {
   flex: 0 0 auto;
   min-height: 180px;
   max-height: 340px;
+}
+
+.chat-logs-toggle {
+  display: flex;
+  align-items: center;
+  gap: 10px;
 }
 
 @media (max-width: 1100px) {
@@ -289,6 +301,10 @@
 
   .chat-top-actions .heymans-msg {
     display: none;
+  }
+
+  .chat-logs-toggle {
+    margin-left: auto;
   }
 
   .chat-top-actions .regular-button {

--- a/heymans/static/css/components.css
+++ b/heymans/static/css/components.css
@@ -297,6 +297,20 @@
   margin: 0;
 }
 
+.clickable-log-row {
+  cursor: pointer;
+}
+
+.clickable-log-row:hover {
+  background: rgba(0, 149, 233, 0.08);
+}
+
+.clickable-log-row:focus-visible {
+  background: rgba(0, 149, 233, 0.14);
+  outline: 2px solid #0095e9;
+  outline-offset: -2px;
+}
+
 .toggle-icon {
   font-size: 1.2em;
 /*  color: gray;*/

--- a/heymans/static/js/vue/iquiz.js
+++ b/heymans/static/js/vue/iquiz.js
@@ -324,6 +324,15 @@ const app = Vue.createApp({
       }
     },
 
+    openUserLogs(studentUsername) {
+      if (!this.quizSelected) return;
+      const username = (studentUsername || '').trim();
+      if (!username || username === '(unknown)') return;
+      const logsUrl = `/app/iquiz/logs/${this.quizSelected}` +
+        `?username=${encodeURIComponent(username)}`;
+      window.open(logsUrl, '_blank');
+    },
+
   }),
 
   computed: {

--- a/heymans/templates/iquiz_sess.html
+++ b/heymans/templates/iquiz_sess.html
@@ -1,7 +1,11 @@
 {% extends "chat_base.html" %}
 
 {% block content %}
+    {% if (iquiz_mode or 'chat') == 'logs' %}
+    {% include 'partials/_chat_logs.html' %}
+    {% else %}
     {% include 'partials/_chat.html' %}
+    {% endif %}
 {% endblock %}
 
 {% block scripts %}

--- a/heymans/templates/iquiz_sess.html
+++ b/heymans/templates/iquiz_sess.html
@@ -6,9 +6,14 @@
 
 {% block scripts %}
     <script>
-        window.INTERACTIVE_QUIZ_ID = {{ interactive_quiz_id }};
+        window.INTERACTIVE_QUIZ_ID = {{ interactive_quiz_id|tojson }};
         window.CHAT_USERNAME = {{ username|tojson }};
-        // TODO 'MODE' ( chat_quiz| q&a | show_logs)? 
+        window.IQUIZ_MODE = {{ (iquiz_mode or 'chat')|tojson }};
+        window.LOG_USERNAME = {{ (log_username or username or '')|tojson }};
     </script>
+    {% if (iquiz_mode or 'chat') == 'logs' %}
+    <script src="{{ url_for('static', filename='js/vue/chat_logs_session.js') }}"></script>
+    {% else %}
     <script src="{{ url_for('static', filename='js/vue/chat_session.js') }}"></script>
+    {% endif %}
 {% endblock %}

--- a/heymans/templates/partials/_iquiz_management.html
+++ b/heymans/templates/partials/_iquiz_management.html
@@ -241,7 +241,16 @@
                 </tr>
               </thead>
               <tbody>
-                <tr v-for="row in conversationOverviewRows" :key="row.username">
+                <tr
+                  v-for="row in conversationOverviewRows"
+                  :key="row.username"
+                  class="clickable-log-row"
+                  @click="openUserLogs(row.username)"
+                  @keydown.enter.prevent="openUserLogs(row.username)"
+                  @keydown.space.prevent="openUserLogs(row.username)"
+                  tabindex="0"
+                  title="Open chat logs for this user"
+                >
                   <td style="padding: 8px; border-bottom: 1px solid #eee;">{{ row.username }}</td>
                   <td style="padding: 8px; border-bottom: 1px solid #eee; text-align: right;">{{ row.started }}</td>
                   <td style="padding: 8px; border-bottom: 1px solid #eee; text-align: right;">{{ row.finished }}</td>

--- a/tests/cheap/test_interactive_quizzes_api.py
+++ b/tests/cheap/test_interactive_quizzes_api.py
@@ -5,9 +5,9 @@ from .test_app import BaseRoutesTestCase
 
 
 class TestInteractiveQuizzesAPI(BaseRoutesTestCase):
-        
+
     def test_basics(self):
-        
+
         # Listing should be empty
         response = self.client.get('/api/interactive_quizzes/list')
         assert response.status_code == HTTPStatus.OK
@@ -77,12 +77,12 @@ class TestInteractiveQuizzesAPI(BaseRoutesTestCase):
         response = self.client.get(f'/api/interactive_quizzes/export/finished/{interactive_quiz_id}')
         assert response.status_code == HTTPStatus.OK
         assert response.json['content'].strip() == '''finished,started,username
-1,1,dummy user'''        
+1,1,dummy user'''
         # Rename quiz
         response = self.client.post(f'/api/interactive_quizzes/rename/{interactive_quiz_id}',
                                     json={"name": "New name"})
         assert response.status_code == HTTPStatus.NO_CONTENT
-        
+
         response = self.client.get(f'/api/interactive_quizzes/get/{interactive_quiz_id}')
         assert response.status_code == HTTPStatus.OK
         assert response.json['name'] == 'New name'
@@ -93,3 +93,37 @@ class TestInteractiveQuizzesAPI(BaseRoutesTestCase):
         response = self.client.get('/api/interactive_quizzes/list')
         assert response.status_code == HTTPStatus.OK
         assert len(response.json) == 0
+
+    def test_logs_hide_seeded_opening_user_message(self):
+        path = Path(__file__).parent / 'testdata/test_source.md'
+        with path.open('rb') as file:
+            document_info = {'public': True}
+            data = {'json': json.dumps(document_info), 'file': (file, path.name)}
+            response = self.client.post('/api/documents/add', data=data)
+        assert response.status_code == HTTPStatus.OK
+        document_id = response.json['document_id']
+
+        response = self.client.post(
+            '/api/interactive_quizzes/new',
+            json={'name': 'Test logs', 'public': False, 'document_id': document_id},
+        )
+        assert response.status_code == HTTPStatus.OK
+        interactive_quiz_id = response.json['interactive_quiz_id']
+
+        response = self.client.post(
+            f'/api/interactive_quizzes/conversation/start/{interactive_quiz_id}',
+            json={'username': 'dummy user'},
+        )
+        assert response.status_code == HTTPStatus.OK
+
+        response = self.client.get(
+            f'/api/interactive_quizzes/logs/{interactive_quiz_id}/dummy%20user'
+        )
+        assert response.status_code == HTTPStatus.OK
+
+        conversations = response.json['conversations']
+        assert len(conversations) == 1
+        messages = conversations[0]['messages']
+        assert len(messages) >= 1
+        assert messages[0]['role'] == 'assistant'
+        assert all(message['text'] != 'Ask me anything!' for message in messages)


### PR DESCRIPTION
Do what was promised in the iquiz page + documentation: give teachers (a view of) chat logs per student.

Allows teachers to check and evaluate students' responses. Accessed by clicking in the table on their "Chat Quiz" dashboard page, in the  "Chat logs and scores" card.