### PR TITLE
Show exam-upload error in UI

### DIFF
--- a/heymans/convert.py
+++ b/heymans/convert.py
@@ -56,7 +56,7 @@ def from_markdown_exam(exam: str | Path, quiz_id: None | int = None) -> dict:
     if exam_name:
         exam_dict['name'] = exam_name.group(1)
     else:
-        raise ValueError('Invalid exam format: Exam should start with a name')
+        raise ValueError('Invalid exam format: Exam should start with a name. (Refer to documentation for exam format.)')
 
     # Extract each question block
     question_blocks = re.split(r'^##\s*', exam, flags=re.MULTILINE)[1:]
@@ -78,7 +78,7 @@ def from_markdown_exam(exam: str | Path, quiz_id: None | int = None) -> dict:
         if any(not part.startswith('-') or '\n' in part .strip()
                for part in parts[1:] if part.strip()):
             raise ValueError(
-                'Invalid exam format: Answer key points should start with -')
+                'Invalid exam format: Answer key points should start with -. (Refer to documentation for exam format.)')
         answer_key = [key.lstrip('-').strip() for key in parts[1:]]
         # Fall back to using name as text for questions without actual text
         if not question_text.strip():

--- a/heymans/static/js/vue/quiz.js
+++ b/heymans/static/js/vue/quiz.js
@@ -284,9 +284,15 @@ const app = Vue.createApp({
             body: JSON.stringify({ questions: markdownContent }),
           });
 
-          // handle different errors for add/questions?
           if (!response.ok) {
-            throw new Error(`Upload failed with status ${response.status}`);
+            let errorDetail = '';
+            try {
+              const data = await response.json();
+              if (data.error) {
+                errorDetail = `: ${data.error}`;
+              }
+            } catch (_) {}
+            throw new Error(`Upload failed with status ${response.status}${errorDetail}`);
           }
 
           const result = await response.json();


### PR DESCRIPTION
This is a simple but very crude way to show the error messages to the user when uploading exams, as opposed to showing a generic 400 error.

This is probably the point at which feedback is the most important, because users are likely to make mistakes when formatting their exam. But also for other uploads users should get informative feedback. We should think of a systematic approach to this, where we design a single error feedback dialog that we use throughout.

We could also use custom HTTP status codes to signal specific things that go wrong, such as 'Incorrect format for uploaded file'.