### PR TITLE
Fix workspace limit + some more minor things

### DIFF
--- a/heymans/__init__.py
+++ b/heymans/__init__.py
@@ -1,3 +1,3 @@
 """AI tutor for education"""
 
-__version__ = '0.5.0'
+__version__ = '0.5.1'

--- a/heymans/config.py
+++ b/heymans/config.py
@@ -27,7 +27,7 @@ google_discovery_url = (
 )
 google_redirect_uri = os.environ.get("GOOGLE_REDIRECT_URI", None)
 # Default model to use
-default_model = os.environ.get('HEYMANS_DEFAULT_MODEL', 'claude-4-6-sonnet')
+default_model = os.environ.get('HEYMANS_DEFAULT_MODEL', 'claude-5-sonnet')
 
 # DEV OPTIONS
 #

--- a/heymans/quizzes.py
+++ b/heymans/quizzes.py
@@ -142,7 +142,7 @@ def grade_attempt(question: str, answer_key: str, answer: str, model: str,
         dummy_reply = 'Invalid dummy reply'
     else:
         dummy_reply = json.dumps(
-            n_answer_key_points * [{'pass': True,
+            n_answer_key_points * [{'pass': random.choice([True, False]),
                                     'motivation': 'Dummy model'}]
         )
     client = chatbot_model(model, dummy_reply=dummy_reply)

--- a/heymans/report.py
+++ b/heymans/report.py
@@ -9,8 +9,13 @@ from datamatrix import DataMatrix, io
 import logging
 from markdown import markdown
 from heymans import grading_formulas, prompts, quizzes, convert
+from sigmund import config as sigmund_config
 logger = logging.getLogger('heymans')
 logging.basicConfig(level=logging.INFO, force=True)
+
+# The proportion of the maximum message length we accept. This is used by the
+# qualitative error analysis, which otherwise may overflow.
+MAX_PROMPT_USE = .8
 
 
 def score(quiz_data: dict | str | Path, model: str,
@@ -170,35 +175,42 @@ def analyze_qualitative_errors(quiz_data: dict | str | Path, model: str,
         The analysis report as a string.
     """
     quiz_data = convert.anything_to_quiz_data(quiz_data)
+    # If the analysis has already been performed, simply return it
     if quiz_data.get('qualitative_error_analysis'):
-        result = quiz_data['qualitative_error_analysis']
-    else:
-        model = chatbot_model(model, dummy_reply='Awesome question')
-        result = ''
-        for i, question in enumerate(quiz_data['questions'], start=1):
-            max_points = quizzes.answer_key_length(question['answer_key'])
-            attempts = []
-            # Filter incorrect responses
-            for attempt in question['attempts']:
-                if attempt['score'] > max_points * threshold:
-                    continue
-                attempt.pop('username', None)
-                attempts.append(attempt)
-            answer_key = '\n- '.join(question['answer_key'])
-            if not attempts:
-                reply = 'No incorrect answers to evaluate'
-            else:
-                # Prepare analysis prompt
-                prompt = prompts.QUALITATIVE_ERROR_ANALYSIS_PROMPT.render(
-                    question_text=question['text'],
-                    answer_key='\n- '.join(question['answer_key']),
-                    student_answers=json.dumps(attempts, indent=True))
-                reply = model.predict(prompt)
-            if callback is not None:
-                callback(question, reply)
-            result += f'# Question {i}\n\n## Question\n\n{question["text"]}\n\n## Answer key\n\n- {answer_key}\n\n## Evaluation\n\n{reply}\n\n'
-            logger.info(f'completed qualitative analysis of question {i}')
-        _write_dst(result, dst)
+        return quiz_data['qualitative_error_analysis']
+    # Otherwise, get to work!
+    model = chatbot_model(model, dummy_reply='Awesome question')
+    result = ''
+    for i, question in enumerate(quiz_data['questions'], start=1):
+        max_points = quizzes.answer_key_length(question['answer_key'])
+        answer_key = '\n- '.join(question['answer_key'])
+        attempts = []
+        # Filter incorrect responses
+        for attempt in question['attempts']:
+            if attempt['score'] > max_points * threshold:
+                continue
+            attempt.pop('username', None)
+            attempts.append(attempt)
+            # Prepare analysis prompt. We do this after each attempt, because
+            # we need to ensure the prompt doesn't become too long.
+            prompt = prompts.QUALITATIVE_ERROR_ANALYSIS_PROMPT.render(
+                question_text=question['text'],
+                answer_key='\n- '.join(question['answer_key']),
+                student_answers=json.dumps(attempts, indent=True))
+            if len(prompt) > sigmund_config.max_message_length * MAX_PROMPT_USE:
+                logger.warning(
+                    f'qualitative-error prompt too long. only using first {len(attempts)} attempts.')
+                break
+        logger.info(f'qualitative-error-prompt length: {len(prompt)}')
+        if not attempts:
+            reply = 'No incorrect answers to evaluate'
+        else:
+            reply = model.predict(prompt)
+        if callback is not None:
+            callback(question, reply)
+        result += f'# Question {i}\n\n## Question\n\n{question["text"]}\n\n## Answer key\n\n- {answer_key}\n\n## Evaluation\n\n{reply}\n\n'
+        logger.info(f'completed qualitative analysis of question {i}')
+    _write_dst(result, dst)
     return result
 
 

--- a/heymans/report.py
+++ b/heymans/report.py
@@ -201,10 +201,10 @@ def analyze_qualitative_errors(quiz_data: dict | str | Path, model: str,
                 logger.warning(
                     f'qualitative-error prompt too long. only using first {len(attempts)} attempts.')
                 break
-        logger.info(f'qualitative-error-prompt length: {len(prompt)}')
         if not attempts:
             reply = 'No incorrect answers to evaluate'
         else:
+            logger.info(f'qualitative-error-prompt length: {len(prompt)}')
             reply = model.predict(prompt)
         if callback is not None:
             callback(question, reply)

--- a/readme.md
+++ b/readme.md
@@ -4,12 +4,11 @@ Copyright 2024-2026 Sebastiaan Mathôt (@smathot), Wouter Kruijne (@wkruijne), U
 
 Heymans AI tutor is a Python library and web app for LLM-based teaching tools. The initial focus will be on automated grading of open exams and interactive quizzes.
 
-This software is in early stages of development and not ready for production.
-
 
 ## Dependencies
 
 For Python dependencies, see `pyproject.toml`. Python 3.10 or later is required. In addition to these, a local `redis` server needs to run for persistent data between sessions. `pandoc` needs to be installed for generating invidual feedback reports.
+
 
 ## Using as Python library
 

--- a/tests/cheap/test_quizzes_api.py
+++ b/tests/cheap/test_quizzes_api.py
@@ -104,7 +104,6 @@ class TestQuizzesGradingAPI(BaseRoutesTestCase):
         response = self.client.get('/api/quizzes/get/1')
         assert response.status_code == HTTPStatus.OK
         for attempt in response.json['questions'][0]['attempts']:
-            assert attempt['score'] == 1
             assert attempt['feedback'][0]['motivation'] == 'Dummy model'
         jsonschema.validate(response.json, json_schemas.QUIZ)
         # Check that state is has_scores


### PR DESCRIPTION
This mainly fixes the workspace-limit issue from #62. If the message now grows too large during a qualitative error analysis, only the first X failed attempts are taken into account. This goes hand in hand with a minor tweak to Sigmund that makes this limit configurable through `.env`. By setting it to 1 million characters, we won't realistically hit the limit anymore. (But even if we do, no catastrophe will ensure.)

A few other minor tweaks are described in the commit messages. Once you've reviewed this, I'll release it as 0.5.1.